### PR TITLE
chore: sync using `atmosphere-ci`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
           EXTRAS=
           PROFILES=
           DIST_PACKAGES=
-          PIP_PACKAGES=cryptography magnum-cluster-api==0.2.5
+          PIP_PACKAGES=cryptography magnum-cluster-api==0.2.6
         cache-from: type=gha,scope=${{ matrix.from }}-${{ matrix.release }}
         cache-to: type=gha,mode=max,scope=${{ matrix.from }}-${{ matrix.release }}
         context: .


### PR DESCRIPTION
Bump magnum-cluster-api version 0.2.5 -> 0.2.6